### PR TITLE
Blur text input when leaving the app, in case the input isn't cleared when focused on mobile

### DIFF
--- a/src/components/FadingTextInput.jsx
+++ b/src/components/FadingTextInput.jsx
@@ -1,5 +1,6 @@
 import { useEffect, useRef } from 'react'
 import styled, { css } from 'styled-components'
+import { useVisibilityChange } from '../useVisibilityChange.js'
 
 const StyledTextarea = styled.textarea(props => css`
   width: 100%;
@@ -55,6 +56,12 @@ export const FadingTextInput = props => {
   const textareaRef = useRef(null)
   const idealHeight = useRef(32)
   const lastScrollHeight = useRef(30)
+  const appOpen = useVisibilityChange()
+
+  useEffect(() => {
+    textareaRef.current.blur()
+  }, [appOpen])
+
   useEffect(() => {
     if (textareaRef) {
       textareaRef.current.style.height = '0px'

--- a/src/useVisibilityChange.js
+++ b/src/useVisibilityChange.js
@@ -1,0 +1,20 @@
+import { useSyncExternalStore } from 'react'
+
+const useVisibilityChangeSubscribe = callback => {
+  document.addEventListener('visibilitychange', callback)
+  return () => {
+    document.removeEventListener('visibilitychange', callback)
+  }
+}
+
+const getVisibilityChangeSnapshot = () => {
+  return document.visibilityState
+}
+
+export function useVisibilityChange () {
+  const visibilityState = useSyncExternalStore(
+    useVisibilityChangeSubscribe,
+    getVisibilityChangeSnapshot
+  )
+  return visibilityState === 'visible'
+}


### PR DESCRIPTION
Had a bit of a panic that if the user leaves the text field focussed. This would un-focus if necessary but may introduce an accessibility/usability error inadvertently. Having it ready just in case.